### PR TITLE
some renaming and pedantic refactor

### DIFF
--- a/src/benchmarks/micro/coreclr/Devirtualization/GuardedThreeClassInterface.cs
+++ b/src/benchmarks/micro/coreclr/Devirtualization/GuardedThreeClassInterface.cs
@@ -2,121 +2,95 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
+using System.Linq;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 
 // Performance test for virtual call dispatch with three
 // possible target classes mixed in varying proportions.
-//
-// Note: for now we type the test input as B[] and not I[]
-// so the simple guessing heuristic in the jit has a class
-// to guess for.
 
-namespace GuardedDevirtualizationThreeClassInterface
-{
-
-interface I
-{
-   int F();
-}
-
-public class B : I
-{
-    int I.F() => 33;
-}
-
-public class D : B, I
-{
-    int I.F() => 44;
-}
-
-public class E : B, I
-{
-    int I.F() => 55;
-}
-
-public class TestInput
-{
-    public const int N = 1000;
-
-    public TestInput(double pB, double pD)
+namespace GuardedDevirtualization
+{   
+    [BenchmarkCategory(Categories.CoreCLR, Categories.Virtual)]
+    public class ThreeClassInterface
     {
-        _pB = pB;
-        _pD = pD;
-        b = GetArray();
-    }
-
-    static Random r = new Random(42);
-
-    double _pB;
-    double _pD;
-    B[] b;
-
-    public B[] Array => b;
-    public override string ToString() => $"pB={_pB:F2} pD={_pD:F2}";
-
-    B[] GetArray()
-    {
-        B[] result = new B[N];
-
-        for (int i = 0; i < N; i++)
+        interface I
         {
-            double p = r.NextDouble();
-
-            if (p <= _pB)
+            int F();
+        }
+    
+        public class B : I
+        {
+            int I.F() => 33;
+        }
+    
+        public class D : B, I
+        {
+            int I.F() => 44;
+        }
+    
+        public class E : B, I
+        {
+            int I.F() => 55;
+        }
+  
+        [Benchmark(OperationsPerInvoke=TestInput.N)]
+        [ArgumentsSource(nameof(GetInput))]
+        public long Call(TestInput testInput)
+        {
+            long sum = 0;
+            
+            // Note: for now we type the test input as B[] and not I[]
+            // so the simple guessing heuristic in the jit has a class
+            // to guess for.
+            B[] input = testInput.Array;
+            for (int i = 0; i < input.Length; i++)
             {
-                result[i] = new B();
+                sum += ((I)input[i]).F();
             }
-            else if (p <= _pB + _pD)
+            return sum;
+        }
+        
+        public static IEnumerable<TestInput> GetInput()
+        {
+            const int S = 3;
+            const double delta = 1.0 / (double) S;
+            
+            for (int i = 0; i <= S; i++)
             {
-                result[i] = new D();
-            }
-            else
-            {
-                result[i] = new E();
+                for (int j = 0; j <= S - i; j++)
+                {
+                    yield return new TestInput(i * delta, j * delta);
+                }
             }
         }
-        return result;
-    }
-}
-
-[BenchmarkCategory(Categories.CoreCLR, Categories.Virtual)]
-public class Interface
-{
-    [Benchmark(OperationsPerInvoke=TestInput.N)]
-    [ArgumentsSource(nameof(GetInput))]
-    public long Call3(TestInput testInput)
-    {
-        long sum = 0;
-        B[] input = testInput.Array;
-        for (int i = 0; i < input.Length; i++)
+    
+        public class TestInput
         {
-            sum += ((I)input[i]).F();
-        }
-        return sum;
-    }
+            public const int N = 1000;
 
-    static int S = 3;
-    static double delta = 1.0 / (double) S;
-
-    public static IEnumerable<TestInput> GetInput()
-    {
-        double pB = 0;
-
-        for (int i = 0; i <= S; i++, pB += delta)
-        {
-            double pD = 0;
-
-            for (int j = 0; j <= S - i; j++, pD += delta)
+            public B[] Array;
+            private double _pB;
+            private double _pD;
+            
+            public TestInput(double pB, double pD)
             {
-                yield return new TestInput(pB, pD);
+                _pB = pB;
+                _pD = pD;
+                Array = ValuesGenerator.Array<double>(N).Select(p =>
+                {
+                    if (p <= _pB)
+                        return new B();
+                    if (p <= _pB + _pD)
+                        return new D();
+                    return new E();
+                }).ToArray();
             }
+    
+            public override string ToString() => $"pB={_pB:F2} pD={_pD:F2}";
         }
     }
-}
-
 }
 
 

--- a/src/benchmarks/micro/coreclr/Devirtualization/GuardedThreeClassVirtual.cs
+++ b/src/benchmarks/micro/coreclr/Devirtualization/GuardedThreeClassVirtual.cs
@@ -2,112 +2,86 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
+using System.Linq;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 
 // Performance test for virtual call dispatch with three
 // possible target classes mixed in varying proportions.
 
-namespace GuardedDevirtualizationThreeClass
-{
-
-public class B
-{
-    public virtual int F() => 33;
-}
-
-public class D : B
-{
-    public override int F() => 44;
-}
-
-public class E : B
-{
-    public override int F() => 55;
-}
-
-public class TestInput
-{
-    public const int N = 1000;
-
-    public TestInput(double pB, double pD)
+namespace GuardedDevirtualization
+{   
+    [BenchmarkCategory(Categories.CoreCLR, Categories.Virtual)]
+    public class ThreeClassVirtual
     {
-        _pB = pB;
-        _pD = pD;
-        b = GetArray();
-    }
-
-    static Random r = new Random(42);
-
-    double _pB;
-    double _pD;
-    B[] b;
-
-    public B[] Array => b;
-    public override string ToString() => $"pB={_pB:F2} pD={_pD:F2}";
-
-    B[] GetArray()
-    {
-        B[] result = new B[N];
-
-        for (int i = 0; i < N; i++)
+        public class B
         {
-            double p = r.NextDouble();
-
-            if (p <= _pB)
+            public virtual int F() => 33;
+        }
+    
+        public class D : B
+        {
+            public override int F() => 44;
+        }
+    
+        public class E : B
+        {
+            public override int F() => 55;
+        }
+        
+        [Benchmark(OperationsPerInvoke=TestInput.N)]
+        [ArgumentsSource(nameof(GetInput))]
+        public long Call(TestInput testInput)
+        {
+            long sum = 0;
+            B[] input = testInput.Array;
+            for (int i = 0; i < input.Length; i++)
             {
-                result[i] = new B();
+                sum += input[i].F();
             }
-            else if (p <= _pB + _pD)
+            return sum;
+        }
+        
+        public static IEnumerable<TestInput> GetInput()
+        {
+            const int S = 3;
+            const double delta = 1.0 / (double) S;
+            
+            for (int i = 0; i <= S; i++)
             {
-                result[i] = new D();
-            }
-            else
-            {
-                result[i] = new E();
+                for (int j = 0; j <= S - i; j++)
+                {
+                    yield return new TestInput(i * delta, j * delta);
+                }
             }
         }
-        return result;
-    }
-}
-
-[BenchmarkCategory(Categories.CoreCLR, Categories.Virtual)]
-public class Virtual
-{
-    [Benchmark(OperationsPerInvoke=TestInput.N)]
-    [ArgumentsSource(nameof(GetInput))]
-    public long Call3(TestInput testInput)
-    {
-        long sum = 0;
-        B[] input = testInput.Array;
-        for (int i = 0; i < input.Length; i++)
+    
+        public class TestInput
         {
-            sum += input[i].F();
-        }
-        return sum;
-    }
+            public const int N = 1000;
 
-    static int S = 3;
-    static double delta = 1.0 / (double) S;
-
-    public static IEnumerable<TestInput> GetInput()
-    {
-        double pB = 0;
-
-        for (int i = 0; i <= S; i++, pB += delta)
-        {
-            double pD = 0;
-
-            for (int j = 0; j <= S - i; j++, pD += delta)
+            public B[] Array;
+            private double _pB;
+            private double _pD;
+            
+            public TestInput(double pB, double pD)
             {
-                yield return new TestInput(pB, pD);
+                _pB = pB;
+                _pD = pD;
+                Array = ValuesGenerator.Array<double>(N).Select(p =>
+                {
+                    if (p <= _pB)
+                        return new B();
+                    if (p <= _pB + _pD)
+                        return new D();
+                    return new E();
+                }).ToArray();
             }
-        }
+    
+            public override string ToString() => $"pB={_pB:F2} pD={_pD:F2}";
+        }     
     }
-}
-
 }
 
 

--- a/src/benchmarks/micro/coreclr/Devirtualization/GuardedTwoClassInterface.cs
+++ b/src/benchmarks/micro/coreclr/Devirtualization/GuardedTwoClassInterface.cs
@@ -2,104 +2,76 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
+using System.Linq;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 
 // Performance test for interface call dispatch with two
 // possible target classes mixed in varying proportions.
-//
-// Note: for now we type the test input as B[] and not I[]
-// so the simple guessing heuristic in the jit has a class
-// to guess for.
 
-namespace GuardedDevirtualizationTwoClassInterface
+namespace GuardedDevirtualization
 {
-
-interface I
-{
-   int F();
-}
-
-public class B : I
-{
-    int I.F() => 33;
-}
-
-public class D : B, I
-{
-    int I.F() => 44;
-}
-
-public class TestInput
-{
-    public const int N = 1000;
-
-    public TestInput(double pB)
+    [BenchmarkCategory(Categories.CoreCLR, Categories.Virtual)]
+    public class TwoClassInterface
     {
-        _pB = pB;
-        b = GetArray();
-    }
-
-    static Random r = new Random(42);
-
-    double _pB;
-    B[] b;
-
-    public B[] Array => b;
-    public override string ToString() => $"pB = {_pB:F2}";
-
-    B[] GetArray()
-    {
-        B[] result = new B[N];
-        for (int i = 0; i < N; i++)
+        interface I
         {
-            double p = r.NextDouble();
-            if (p > _pB)
+            int F();
+        }
+
+        public class B : I
+        {
+            int I.F() => 33;
+        }
+
+        public class D : B, I
+        {
+            int I.F() => 44;
+        }
+
+        [Benchmark(OperationsPerInvoke = TestInput.N)]
+        [ArgumentsSource(nameof(GetInput))]
+        public long Call(TestInput testInput)
+        {
+            long sum = 0;
+            
+            // Note: for now we type the test input as B[] and not I[]
+            // so the simple guessing heuristic in the jit has a class
+            // to guess for.
+            B[] input = testInput.Array;
+            for (int i = 0; i < input.Length; i++)
             {
-                result[i] = new D();
+                sum += ((I)input[i]).F();
             }
-            else
+
+            return sum;
+        }
+
+        public static IEnumerable<TestInput> GetInput()
+        {
+            for (double pB = 0; pB <= 1.0; pB += 0.1)
             {
-                result[i] = new B();
+                yield return new TestInput(pB);
             }
         }
-        return result;
-    }
-}
 
-[BenchmarkCategory(Categories.CoreCLR, Categories.Virtual)]
-public class Interface
-{
-    [Benchmark(OperationsPerInvoke=TestInput.N)]
-    [ArgumentsSource(nameof(GetInput))]
-    public long Call2(TestInput testInput)
-    {
-        long sum = 0;
-
-        B[] input = testInput.Array;
-        for (int i = 0; i < input.Length; i++)
+        public class TestInput
         {
-            sum += ((I)input[i]).F();
-        }
-        return sum;
-    }
+            public const int N = 1000;
 
-    static int S = 10;
-    static double delta = 1.0 / (double) S;
+            public B[] Array;
+            private double _pB;
 
-    public static IEnumerable<TestInput> GetInput()
-    {
-        double pB = 0;
+            public TestInput(double pB)
+            {
+                _pB = pB;
+                Array = ValuesGenerator.Array<double>(N).Select(p => p > _pB ? new D() : new B()).ToArray();
+            }
 
-        for (int i = 0; i <= S; i++, pB += delta)
-        {
-            yield return new TestInput(pB);
+            public override string ToString() => $"pB = {_pB:F2}";
         }
     }
-}
-
 }
 
 


### PR DESCRIPTION
this is my pedantic proposal to https://github.com/dotnet/performance/pull/174

When I was porting all the benchmarks to perf repo I  realized that most of them have very long names, which are used as IDs in BenchView and don't look good in the web browser.

Before:

```log
GuardedDevirtualizationThreeClass.Virtual.Call3
GuardedDevirtualizationThreeClassInterface.Interface.Call3
GuardedDevirtualizationTwoClass.Virtual.Call2
GuardedDevirtualizationTwoClassInterface.Interface.Call2
```

After:

```
GuardedDevirtualization.ThreeClassVirtual.Call
GuardedDevirtualization.ThreeClassInterface.Call
GuardedDevirtualization.TwoClassVirtual.Call
GuardedDevirtualization.TwoClassInterface.Call
```

Also instead of using `Random` we can use a [ValuesGenerator](https://github.com/dotnet/performance/blob/master/src/benchmarks/micro/ValuesGenerator.cs) which was added to perf repo to avoid common issues when working with random input.

@AndyAyersMS this PR is very subjective, if you don't like the changes please close it and I am going to merge https://github.com/dotnet/performance/pull/174 without it immediately.